### PR TITLE
Add doc, test, and intents for _constant_ and _natlog_ interfaces

### DIFF
--- a/aoslib/_awips.pyf
+++ b/aoslib/_awips.pyf
@@ -961,7 +961,7 @@ python module _awips ! in
             real dimension(nlvls),depend(nlvls) :: tvir
         end subroutine virtualt
         subroutine constant(a,const_bn,mni,ni,nj) ! in :_aoslib:constant.f
-            real dimension(mni,nj), intent(out) :: a
+            real dimension(mni,nj), intent(in,out) :: a
             real, intent(in) :: const_bn
             integer, intent(hide),depend(a) :: mni=shape(a,0)
             integer, optional,check(ni<=shape(a,0)), depend(a) :: ni=shape(a,0)

--- a/aoslib/awips.py
+++ b/aoslib/awips.py
@@ -688,12 +688,28 @@ def cgp(tempip, dwptip, presip, thetawip, toppres, deltap, **kwargs):
 
 def constant(a,const,**kwargs):
     """
-    Sets an existing array to an array of constants
-    a: initial array
-    const: constant for each entry to be set to
-    mni: inital number of rows in array
-    ni: number of columns in array to set to constant
-    nj: number of columns in array
+    Modifies an existing array, replacing entries with a constant value.
+
+    Parameters
+    ----------
+    a: array_like, 2D
+        Input array.
+    const: real
+	Real number to reset array values to.
+    ni: int, optional
+	Number of rows in array to modify
+
+    Returns
+    -------
+    a: array_like, 2D
+	Output array with desired entries set to const
+
+    Examples
+    --------
+    >>> import aoslib
+    >>> aoslib.constant([[1000., 950.],[925., 975.]], -3.14, ni=1)
+    array([[-3.14, -3.14],[925., 975.]], dtype=float32)
+
     """
     return _awips.constant(a,const,**kwargs)
 

--- a/aoslib/tests/test_aoslib.py
+++ b/aoslib/tests/test_aoslib.py
@@ -134,6 +134,9 @@ def test_natlog():
     if verbose:
         print "natlog:"
         print aoslib.natlog(a)
+        print aoslib.natlog(a,ni=3)
+        print aoslib.natlog(a,ni=2)
+        print aoslib.natlog(a,ni=1)
 
     assert_allclose(aoslib.natlog(a), three_rows, atol=ATOL)
     assert_allclose(aoslib.natlog(a,ni=3), three_rows, atol=ATOL)
@@ -469,17 +472,39 @@ def test_calctw():
 
 def test_constant():
     # a, const, ni, nj
-    a = np.array([[1000., 950.], [925., 975.]],dtype='float32')
-    const = 1.0
-    mni = 2
-    nj = 2
+    a = [[1000., 950.],[925., 975.],[-960., -1020.]]
+    const = -3.14
 
-    result = np.array([[1.0,1.0],[1.0,1.0]],dtype='float32')
+    three_rows = np.array(
+	[[-3.14,-3.14],
+	[-3.14,-3.14],
+	[-3.14, -3.14]],dtype='float32')
+    two_rows = np.array(
+	[[-3.14,-3.14],
+	[-3.14,-3.14],
+	[-960., -1020.]],dtype='float32')
+    one_row = np.array(
+	[[-3.14,-3.14],
+	[925.,975.],
+	[-960., -1020.]],dtype='float32')
+    zero_rows = np.array(
+        [[1000., 950.], 
+        [925., 975.],
+        [-960., -1020.]],dtype='float32')
+
     if verbose:
         print "constant:"
         print aoslib.constant(a, const)
+        print aoslib.constant(a, const, ni=3)
+        print aoslib.constant(a, const, ni=2)
+        print aoslib.constant(a, const, ni=1)
+        print aoslib.constant(a, const, ni=0)
 
-    assert_allclose(aoslib.constant(a,const), result, atol=ATOL)
+    assert_allclose(aoslib.constant(a,const), three_rows, atol=ATOL)
+    assert_allclose(aoslib.constant(a,const,ni=3), three_rows, atol=ATOL)
+    assert_allclose(aoslib.constant(a,const,ni=2), two_rows, atol=ATOL)
+    assert_allclose(aoslib.constant(a,const,ni=1), one_row, atol=ATOL)
+    assert_allclose(aoslib.constant(a,const,ni=0), zero_rows, atol=ATOL)
 
 
 def test_crossvectors():


### PR DESCRIPTION
Changes based off of _calctd_ interface example.

For _constant_ interface, used "intent(in,out)" for array, a.
